### PR TITLE
Un esempio di utilizzo dell'appsettings

### DIFF
--- a/BlazorDevIta.ERP.BlazorWasm/Client/Services/DataServices.cs
+++ b/BlazorDevIta.ERP.BlazorWasm/Client/Services/DataServices.cs
@@ -2,58 +2,58 @@
 using BlazorDevIta.UI.Services;
 using System.Net.Http.Json;
 
-namespace BlazorDevIta.ERP.BlazorWasm.Client.Services
+namespace BlazorDevIta.ERP.BlazorWasm.Client.Services;
+
+public class DataServices<ListItemType, DetailsType, IdType> 
+	: IDataServices<ListItemType, DetailsType, IdType>
+	where DetailsType : BaseDetails<IdType>
+	where ListItemType : BaseListItem<IdType>
 {
-	public class DataServices<ListItemType, DetailsType, IdType> 
-		: IDataServices<ListItemType, DetailsType, IdType>
-		where DetailsType : BaseDetails<IdType>
-		where ListItemType : BaseListItem<IdType>
+	private readonly HttpClient _http;
+
+	public string epCreate { get; init; }
+	public string epDelete { get; init; }
+	public string epGetById { get; init; }
+	public string epUpdate { get; init; }
+
+	public string epGetAll { get; init; }
+
+	public DataServices(HttpClient http, IConfiguration configuration)
 	{
-		private readonly HttpClient _http;
-        private readonly IConfiguration _configuration;
+		_http = http;
+		configuration.GetSection($"DataServices:{typeof(DetailsType).Name}").Bind(this);
+		configuration.GetSection($"DataServices:{typeof(ListItemType).Name}").Bind(this);
 
-        public DataServices(HttpClient http, IConfiguration configuration)
-		{
-			_http = http;
-			_configuration = configuration;
-		}
-
-		public Task CreateAsync(DetailsType details)
-		{
-			var baseUrl = getBaseUrl<DetailsType>();
-			return _http.PostAsJsonAsync($"{baseUrl}", details);
-		}
-
-		public Task DeleteAsync(IdType id)
-		{
-			var baseUrl = getBaseUrl<DetailsType>();
-			return _http.DeleteAsync($"{baseUrl}/{id}");
-		}
-
-		public Task<DetailsType?> GetByIdAsync(IdType id)
-		{
-			var baseUrl = getBaseUrl<DetailsType>();
-			return _http.GetFromJsonAsync<DetailsType?>($"{baseUrl}/{id}")!;
-		}
-
-		public Task<Page<ListItemType, IdType>> GetAllAsync(PageParameters parameters)
-		{
-			var baseUrl = getBaseUrl<ListItemType>();
-			return _http.GetFromJsonAsync<Page<ListItemType, IdType>>(
-				$"{baseUrl}?OrderBy={parameters.OrderBy}&OrderByDirection={parameters.OrderByDirection}")!;
-		}
-
-		public Task UpdateAsync(DetailsType details)
-		{
-			var baseUrl = getBaseUrl<DetailsType>();
-			return _http.PutAsJsonAsync($"{baseUrl}/{details.Id}", details);
-		}
-
-		private string getBaseUrl<T>()
-        {
-			var baseUrl = _configuration[$"ApiUrls:{typeof(T).Name}"];
-			if (baseUrl == null) throw new Exception($"ApiUrls:{typeof(T).Name} not configured");
-			return baseUrl;
-		}
+		if (string.IsNullOrEmpty(epCreate))
+			throw new Exception($"DataServices:{nameof(epCreate)} not configured");
+		if (string.IsNullOrEmpty(epDelete))
+			throw new Exception($"DataServices:{nameof(epDelete)} not configured");
+		if (string.IsNullOrEmpty(epGetById))
+			throw new Exception($"DataServices:{nameof(epGetById)} not configured");
+		if (string.IsNullOrEmpty(epUpdate))
+			throw new Exception($"DataServices:{nameof(epUpdate)} not configured");
+		if (string.IsNullOrEmpty(epGetAll))
+			throw new Exception($"DataServices:{nameof(epGetAll)} not configured");
 	}
+
+	public Task CreateAsync(DetailsType details)
+	=> _http.PostAsJsonAsync(epCreate, details);
+	
+
+	public Task DeleteAsync(IdType id)
+	=> _http.DeleteAsync($"{epDelete}/{id}");
+	
+
+	public Task<DetailsType?> GetByIdAsync(IdType id)
+	=> _http.GetFromJsonAsync<DetailsType?>($"{epGetById}/{id}")!;
+	
+
+	public Task<Page<ListItemType, IdType>> GetAllAsync(PageParameters parameters)
+	=> _http.GetFromJsonAsync<Page<ListItemType, IdType>>(
+			$"{epGetAll}?OrderBy={parameters.OrderBy}&OrderByDirection={parameters.OrderByDirection}")!;
+	
+
+	public Task UpdateAsync(DetailsType details)
+	=> _http.PutAsJsonAsync($"{epUpdate}/{details.Id}", details);
+
 }

--- a/BlazorDevIta.ERP.BlazorWasm/Client/wwwroot/appsettings.json
+++ b/BlazorDevIta.ERP.BlazorWasm/Client/wwwroot/appsettings.json
@@ -1,6 +1,13 @@
 {
-  "ApiUrls": {
-    "WeatherForecastListItem": "WeatherForecast",
-    "WeatherForecastDetails": "WeatherForecast"
+  "DataServices": {
+    "WeatherForecastDetails": {
+      "epCreate": "WeatherForecast",
+      "epDelete": "WeatherForecast",
+      "epGetById": "WeatherForecast",
+      "epUpdate": "WeatherForecast"
+    },
+    "WeatherForecastListItem": {
+      "epGetAll": "WeatherForecast"
+    }
   }
 }

--- a/BlazorDevIta.ERP.BlazorWasm/Server/Extensions/WebApplicationExtensions.cs
+++ b/BlazorDevIta.ERP.BlazorWasm/Server/Extensions/WebApplicationExtensions.cs
@@ -1,0 +1,40 @@
+﻿using BlazorDevIta.ERP.Business.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace BlazorDevIta.ERP.BlazorWasm.Server.Extensions;
+
+public static class WebApplicationExtensions
+{
+    public static async Task<IApplicationBuilder> InizializeDatabases(this WebApplication app)
+    {
+        using (var serviceScope = app.Services.GetService<IServiceScopeFactory>()!.CreateScope())
+        {
+            var serviceProvider = serviceScope.ServiceProvider;
+            IConfiguration config = serviceProvider.GetRequiredService<IConfiguration>();
+            var appCtx = serviceProvider.GetRequiredService<ERPDbContext>();
+            
+            //Applica le ultime migrazioni
+            appCtx.Database.Migrate(); 
+
+            await EnsureSetup(config, appCtx);
+
+        }
+        return app;
+    }
+
+    private static Task EnsureSetup(IConfiguration config, ERPDbContext ctx)
+    {
+        if (!ctx.WeatherForecasts.Any())
+        {
+            //Per esempio posso precaricare la tabella WeatherForecasts con valori iniziali configurati nell'appsettings
+
+            //var weatherForecasts = config.GetSection(nameof(ctx.WeatherForecasts)).Get<IEnumerable<WeatherForecast>>();
+            //foreach (var record in weatherForecasts)
+            //{
+            //    ctx.Add(record);
+            //}
+            //ctx.SaveChanges();
+        }
+        return Task.CompletedTask;
+    }
+}

--- a/BlazorDevIta.ERP.BlazorWasm/Server/Program.cs
+++ b/BlazorDevIta.ERP.BlazorWasm/Server/Program.cs
@@ -1,4 +1,5 @@
 using BlazorDevIta.ERP.BlazorWasm.Server.Configurations;
+using BlazorDevIta.ERP.BlazorWasm.Server.Extensions;
 using BlazorDevIta.ERP.Business.Data;
 using BlazorDevIta.ERP.Infrastructure;
 using BlazorDevIta.ERP.Infrastructure.EF;
@@ -23,6 +24,9 @@ builder.Services.AddAutoMapper(typeof(MappingProfile));
 builder.Services.AddScoped(typeof(IRepository<,>), typeof(EFRepository<,>));
 
 var app = builder.Build();
+
+//Applica le migrazioni mancanti sul DB e inizializza le tabelle se necessario
+await app.InizializeDatabases();
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())


### PR DESCRIPTION
La PR è un esempio di come si possa utilizzare l'appsettings.json per configurare gli endpoint associati a delle API o anche importare dei dati di default da caricare su un database.
Il metodo WebApplicationExtensions.InizializeDatabases consente in particolare di sincronizzare il db all'ultima migrazione (o anche di crealo), eseguendo anche un seeding dei dati qualora le tabelle risultassero vuote, importando da un appsettings.json opportunamente configurato.